### PR TITLE
revert close consumer conn

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -838,7 +838,8 @@ func (c *connection) handleCloseConsumer(closeConsumer *pb.CommandCloseConsumer)
 	consumerID := closeConsumer.GetConsumerId()
 	c.log.Infof("Broker notification of Closed consumer: %d", consumerID)
 
-	c.changeState(connectionClosed)
+	// no need to close consumer conn now
+	// c.changeState(connectionClosed)
 
 	if consumer, ok := c.consumerHandler(consumerID); ok {
 		consumer.ConnectionClosed()


### PR DESCRIPTION
consumer的链接管理看起来比producer健壮，这里先不关底层的tcp链接，解决自动化用例的问题